### PR TITLE
Use `angular.extend` to update position in scope.

### DIFF
--- a/src/js/directives/wg-widget.js
+++ b/src/js/directives/wg-widget.js
@@ -43,7 +43,7 @@
         
         function updateRendering() {
           element.css(gridCtrl.getWidgetStyle(widget));
-          scope.position = widget.getPosition();
+          angular.extend(scope.position, widget.getPosition());
         }
         
         scope.$on('wg-update-rendering', updateRendering);


### PR DESCRIPTION
This prevents dereferencing the original position object, which is undesirable
if there are other properties than `top`, `left`, `width` and `height` on the
position object.

For example if the position object is defined as follows:

    $scope.position = {
      top: 0,
      left: 0,
      width: 1,
      height: 1,
      name: "my first widget"
    }

Updating the widget would replace the original object, thus losing the `name`
property. Using `angular.extend` solves this by just copying all enumerable
properties from the object obtained through `Widget.prototype.getPosition` to
the original position object and leaves all other properties untouched.